### PR TITLE
[Style] #25 - SearchViewController UI 구현

### DIFF
--- a/PPPCLUB-iOS.xcodeproj/project.pbxproj
+++ b/PPPCLUB-iOS.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		05CD07D52A5C9690003EEE84 /* DetailUniqueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07D42A5C9690003EEE84 /* DetailUniqueView.swift */; };
 		05CD07D92A5D2505003EEE84 /* DetailArticleRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07D82A5D2505003EEE84 /* DetailArticleRequestView.swift */; };
 		05CD07DB2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07DA2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift */; };
+		05CD07DD2A5E9C37003EEE84 /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */; };
+		05CD07E22A5EA072003EEE84 /* SearchListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07E12A5EA072003EEE84 /* SearchListModel.swift */; };
 		D221886D2A5924C600F097C7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221886C2A5924C600F097C7 /* DetailViewController.swift */; };
 		D221886F2A5924D200F097C7 /* DetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221886E2A5924D200F097C7 /* DetailTopView.swift */; };
 		D22188772A5925F100F097C7 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D22188762A5925F100F097C7 /* Pretendard-SemiBold.otf */; };
@@ -26,11 +28,6 @@
 		D224D4962A5D1D0600B014ED /* TicketResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4952A5D1D0600B014ED /* TicketResultView.swift */; };
 		D224D4982A5D1D6300B014ED /* TicketSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4972A5D1D6300B014ED /* TicketSuccessView.swift */; };
 		D224D49A2A5D1D7400B014ED /* TicketFailureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4992A5D1D7400B014ED /* TicketFailureView.swift */; };
-		D224D4B02A5DFAC400B014ED /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4AF2A5DFAC300B014ED /* Pretendard-Bold.otf */; };
-		D224D4B22A5DFAE900B014ED /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B12A5DFAE900B014ED /* Pretendard-Regular.otf */; };
-		D224D4B42A5DFB6B00B014ED /* Unbounded-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B32A5DFB6B00B014ED /* Unbounded-Regular.ttf */; };
-		D224D4B62A5DFB7300B014ED /* Unbounded-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B52A5DFB7300B014ED /* Unbounded-Light.ttf */; };
-		D224D4B82A5DFBC300B014ED /* Unbounded-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B72A5DFBC200B014ED /* Unbounded-SemiBold.ttf */; };
 		D224D49C2A5D9A9700B014ED /* MySavedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D49B2A5D9A9700B014ED /* MySavedView.swift */; };
 		D224D49F2A5DA6B900B014ED /* MyInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D49E2A5DA6B900B014ED /* MyInfoTableViewCell.swift */; };
 		D224D4A12A5DA95600B014ED /* MyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4A02A5DA95600B014ED /* MyInfoView.swift */; };
@@ -38,6 +35,11 @@
 		D224D4A92A5DB66800B014ED /* MyInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4A82A5DB66800B014ED /* MyInfoModel.swift */; };
 		D224D4AB2A5DCB7800B014ED /* MySeparatorFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4AA2A5DCB7800B014ED /* MySeparatorFooterView.swift */; };
 		D224D4AD2A5DF15600B014ED /* MyAccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D224D4AC2A5DF15600B014ED /* MyAccountModel.swift */; };
+		D224D4B02A5DFAC400B014ED /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4AF2A5DFAC300B014ED /* Pretendard-Bold.otf */; };
+		D224D4B22A5DFAE900B014ED /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B12A5DFAE900B014ED /* Pretendard-Regular.otf */; };
+		D224D4B42A5DFB6B00B014ED /* Unbounded-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B32A5DFB6B00B014ED /* Unbounded-Regular.ttf */; };
+		D224D4B62A5DFB7300B014ED /* Unbounded-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B52A5DFB7300B014ED /* Unbounded-Light.ttf */; };
+		D224D4B82A5DFBC300B014ED /* Unbounded-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D224D4B72A5DFBC200B014ED /* Unbounded-SemiBold.ttf */; };
 		D2614A462A52836E00869710 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2614A452A52836E00869710 /* AppDelegate.swift */; };
 		D2614A482A52836E00869710 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2614A472A52836E00869710 /* SceneDelegate.swift */; };
 		D2614A4D2A52836F00869710 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2614A4B2A52836F00869710 /* Main.storyboard */; };
@@ -99,6 +101,8 @@
 		05CD07D42A5C9690003EEE84 /* DetailUniqueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailUniqueView.swift; sourceTree = "<group>"; };
 		05CD07D82A5D2505003EEE84 /* DetailArticleRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailArticleRequestView.swift; sourceTree = "<group>"; };
 		05CD07DA2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMoveToArticleView.swift; sourceTree = "<group>"; };
+		05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
+		05CD07E12A5EA072003EEE84 /* SearchListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListModel.swift; sourceTree = "<group>"; };
 		D221886C2A5924C600F097C7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		D221886E2A5924D200F097C7 /* DetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTopView.swift; sourceTree = "<group>"; };
 		D22188762A5925F100F097C7 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -109,11 +113,6 @@
 		D224D4952A5D1D0600B014ED /* TicketResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketResultView.swift; sourceTree = "<group>"; };
 		D224D4972A5D1D6300B014ED /* TicketSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketSuccessView.swift; sourceTree = "<group>"; };
 		D224D4992A5D1D7400B014ED /* TicketFailureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketFailureView.swift; sourceTree = "<group>"; };
-		D224D4AF2A5DFAC300B014ED /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
-		D224D4B12A5DFAE900B014ED /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
-		D224D4B32A5DFB6B00B014ED /* Unbounded-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Regular.ttf"; sourceTree = "<group>"; };
-		D224D4B52A5DFB7300B014ED /* Unbounded-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Light.ttf"; sourceTree = "<group>"; };
-		D224D4B72A5DFBC200B014ED /* Unbounded-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-SemiBold.ttf"; sourceTree = "<group>"; };
 		D224D49B2A5D9A9700B014ED /* MySavedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySavedView.swift; sourceTree = "<group>"; };
 		D224D49E2A5DA6B900B014ED /* MyInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoTableViewCell.swift; sourceTree = "<group>"; };
 		D224D4A02A5DA95600B014ED /* MyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoView.swift; sourceTree = "<group>"; };
@@ -121,6 +120,11 @@
 		D224D4A82A5DB66800B014ED /* MyInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoModel.swift; sourceTree = "<group>"; };
 		D224D4AA2A5DCB7800B014ED /* MySeparatorFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySeparatorFooterView.swift; sourceTree = "<group>"; };
 		D224D4AC2A5DF15600B014ED /* MyAccountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountModel.swift; sourceTree = "<group>"; };
+		D224D4AF2A5DFAC300B014ED /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
+		D224D4B12A5DFAE900B014ED /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
+		D224D4B32A5DFB6B00B014ED /* Unbounded-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Regular.ttf"; sourceTree = "<group>"; };
+		D224D4B52A5DFB7300B014ED /* Unbounded-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Light.ttf"; sourceTree = "<group>"; };
+		D224D4B72A5DFBC200B014ED /* Unbounded-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-SemiBold.ttf"; sourceTree = "<group>"; };
 		D2614A422A52836E00869710 /* PPPCLUB-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PPPCLUB-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2614A452A52836E00869710 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D2614A472A52836E00869710 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -213,6 +217,30 @@
 			isa = PBXGroup;
 			children = (
 				0583268D2A5C0158004A295F /* DetailTagModel.swift */,
+			);
+			path = APIModel;
+			sourceTree = "<group>";
+		};
+		05CD07DE2A5EA024003EEE84 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				05CD07E02A5EA041003EEE84 /* APIModel */,
+				05CD07DF2A5EA03A003EEE84 /* Model */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		05CD07DF2A5EA03A003EEE84 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		05CD07E02A5EA041003EEE84 /* APIModel */ = {
+			isa = PBXGroup;
+			children = (
+				05CD07E12A5EA072003EEE84 /* SearchListModel.swift */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -396,6 +424,7 @@
 		D2614A9B2A5291E300869710 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				05CD07DE2A5EA024003EEE84 /* Search */,
 				D224D4A42A5DB5F900B014ED /* My */,
 				D265940F2A5CF43B0089E56A /* Ticket */,
 				0583268A2A5C012C004A295F /* Detail */,
@@ -557,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				D2B096192A529994007BC756 /* SearchView.swift */,
+				05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -726,6 +756,7 @@
 				D2B0961A2A529994007BC756 /* SearchView.swift in Sources */,
 				D2614A782A528D5800869710 /* UIFont+.swift in Sources */,
 				D2B096242A529A8C007BC756 /* TicketViewController.swift in Sources */,
+				05CD07E22A5EA072003EEE84 /* SearchListModel.swift in Sources */,
 				D2614A7A2A528D6E00869710 /* UITabbar+.swift in Sources */,
 				D2614A5C2A528C2300869710 /* URLs.swift in Sources */,
 				05CD07D92A5D2505003EEE84 /* DetailArticleRequestView.swift in Sources */,
@@ -753,6 +784,7 @@
 				D224D4AB2A5DCB7800B014ED /* MySeparatorFooterView.swift in Sources */,
 				0583268E2A5C0158004A295F /* DetailTagModel.swift in Sources */,
 				D224D4962A5D1D0600B014ED /* TicketResultView.swift in Sources */,
+				05CD07DD2A5E9C37003EEE84 /* SearchTableViewCell.swift in Sources */,
 				D2B096162A529963007BC756 /* TicketTicketView.swift in Sources */,
 				D2614A622A528C5100869710 /* UIView+.swift in Sources */,
 				D2614A682A528C9100869710 /* UITextField+.swift in Sources */,

--- a/PPPCLUB-iOS.xcodeproj/project.pbxproj
+++ b/PPPCLUB-iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		05CD07DB2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07DA2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift */; };
 		05CD07DD2A5E9C37003EEE84 /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */; };
 		05CD07E22A5EA072003EEE84 /* SearchListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07E12A5EA072003EEE84 /* SearchListModel.swift */; };
+		05CD07E52A5ED7D8003EEE84 /* SearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CD07E42A5ED7D8003EEE84 /* SearchHeaderView.swift */; };
 		D221886D2A5924C600F097C7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221886C2A5924C600F097C7 /* DetailViewController.swift */; };
 		D221886F2A5924D200F097C7 /* DetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221886E2A5924D200F097C7 /* DetailTopView.swift */; };
 		D22188772A5925F100F097C7 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = D22188762A5925F100F097C7 /* Pretendard-SemiBold.otf */; };
@@ -103,6 +104,7 @@
 		05CD07DA2A5D9CA5003EEE84 /* DetailMoveToArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMoveToArticleView.swift; sourceTree = "<group>"; };
 		05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
 		05CD07E12A5EA072003EEE84 /* SearchListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListModel.swift; sourceTree = "<group>"; };
+		05CD07E42A5ED7D8003EEE84 /* SearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeaderView.swift; sourceTree = "<group>"; };
 		D221886C2A5924C600F097C7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		D221886E2A5924D200F097C7 /* DetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTopView.swift; sourceTree = "<group>"; };
 		D22188762A5925F100F097C7 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 			children = (
 				D2B096192A529994007BC756 /* SearchView.swift */,
 				05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */,
+				05CD07E42A5ED7D8003EEE84 /* SearchHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -754,6 +757,7 @@
 				058326892A5C00C7004A295F /* DetailTagCollectionViewCell.swift in Sources */,
 				D224D4A92A5DB66800B014ED /* MyInfoModel.swift in Sources */,
 				D2B0961A2A529994007BC756 /* SearchView.swift in Sources */,
+				05CD07E52A5ED7D8003EEE84 /* SearchHeaderView.swift in Sources */,
 				D2614A782A528D5800869710 /* UIFont+.swift in Sources */,
 				D2B096242A529A8C007BC756 /* TicketViewController.swift in Sources */,
 				05CD07E22A5EA072003EEE84 /* SearchListModel.swift in Sources */,

--- a/PPPCLUB-iOS/Data/Search/APIModel/SearchListModel.swift
+++ b/PPPCLUB-iOS/Data/Search/APIModel/SearchListModel.swift
@@ -1,0 +1,60 @@
+//
+//  SearchListModel.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/12.
+//
+
+import UIKit
+
+struct SearchListModel {
+    let searchList: [SearchList]
+}
+
+struct SearchList {
+    let image: UIImage
+    let name: String
+    let location: String
+}
+
+extension SearchListModel {
+    static func dummy() -> SearchListModel {
+        return SearchListModel(searchList: [SearchList(image: Image.mockBookStore,
+                                                       name: "문학살롱 초고",
+                                                       location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                       name: "문학살롱 초고",
+                                                       location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+                                            SearchList(image: Image.mockBookStore,
+                                                        name: "문학살롱 초고",
+                                                        location: "서울특별시 영등포구 여의대로 108(여의도동, 파크원) 지하 2층"),
+        ])
+    }
+}

--- a/PPPCLUB-iOS/Global/Extension/UIFont+.swift
+++ b/PPPCLUB-iOS/Global/Extension/UIFont+.swift
@@ -78,11 +78,11 @@ extension UIFont{
         return UIFont(name: "Unbounded-Regular", size: 16)!
     }
     
-    class var pppCaption: UIFont {
+    class var pppEnCaption: UIFont {
         return UIFont(name: "Unbounded-Light", size: 14)!
     }
     
-    class var pppNav: UIFont {
+    class var pppEnNav: UIFont {
         return UIFont(name: "Unbounded-Light", size: 12)!
     }
 }

--- a/PPPCLUB-iOS/Info.plist
+++ b/PPPCLUB-iOS/Info.plist
@@ -8,8 +8,8 @@
 		<string>Unbounded-Light.ttf</string>
 		<string>Unbounded-Regular.ttf</string>
 		<string>Pretendard-Bold.otf</string>
-		<string>Pretendard-Medium.otf</string>
-		<string>Pretendard-Semibold.otf</string>
+		<string>Pretendard-Regular.otf</string>
+		<string>Pretendard-SemiBold.otf</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/PPPCLUB-iOS/Presentation/Detail/View/DetailMoveToArticleView.swift
+++ b/PPPCLUB-iOS/Presentation/Detail/View/DetailMoveToArticleView.swift
@@ -45,7 +45,7 @@ final class DetailMoveToArticleView: UIView {
         shopImageButton.do {
             $0.setImage(UIImage(systemName: "pencil"), for: .normal)
             $0.layer.cornerRadius = 10
-            $0.backgroundColor = .pppMainPink
+//            $0.backgroundColor = .pppMainPink
         }
         
         goReadButton.do {

--- a/PPPCLUB-iOS/Presentation/Detail/View/DetailMoveToArticleView.swift
+++ b/PPPCLUB-iOS/Presentation/Detail/View/DetailMoveToArticleView.swift
@@ -45,7 +45,6 @@ final class DetailMoveToArticleView: UIView {
         shopImageButton.do {
             $0.setImage(UIImage(systemName: "pencil"), for: .normal)
             $0.layer.cornerRadius = 10
-//            $0.backgroundColor = .pppMainPink
         }
         
         goReadButton.do {

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchHeaderView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchHeaderView.swift
@@ -1,0 +1,53 @@
+//
+//  SearchHeaderView.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/12.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchHeaderView: UIView {
+    
+    // MARK: - UI Components
+    
+    lazy var allLabel = UILabel()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        style()
+        hierarchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {        
+        allLabel.do {
+            $0.text = "전체"
+            $0.font = .pppSubHead1
+            $0.textColor = .pppBlack
+        }
+    }
+    
+    private func hierarchy() {
+        self.addSubview(allLabel)
+    }
+    
+    private func layout() {
+        allLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(10)
+            $0.leading.equalToSuperview()
+        }
+    }
+}

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
@@ -52,6 +52,7 @@ class SearchTableViewCell: UITableViewCell {
         locationLabel.do {
             $0.font = .pppCaption1
             $0.textColor = .pppGrey6
+            $0.numberOfLines = 2
         }
         
         infoStackView.do {
@@ -77,6 +78,7 @@ class SearchTableViewCell: UITableViewCell {
         infoStackView.snp.makeConstraints {
             $0.centerY.equalTo(placeImageView)
             $0.leading.equalTo(placeImageView.snp.trailing).offset(12)
+            $0.trailing.equalToSuperview().inset(10)
         }
     }
 }

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
@@ -1,0 +1,93 @@
+//
+//  SearchTableViewCell.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/12.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class SearchTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "SearchTableViewCell"
+    
+    // MARK: - UI Components
+    
+    lazy var placeImageView = UIImageView()
+    lazy var placeNameLabel = UILabel()
+    lazy var locationLabel = UILabel()
+    private lazy var infoStackView = UIStackView(arrangedSubviews: [placeNameLabel,
+                                                                    locationLabel])
+    
+    // MARK: - init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setConstraint()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    func setUI() {
+        placeImageView.do {
+            $0.layer.cornerRadius = 5
+            $0.layer.masksToBounds = true
+            $0.clipsToBounds = true
+            $0.contentMode = .scaleToFill
+        }
+        
+        placeNameLabel.do {
+            $0.font = .pppBody4
+            $0.textColor = .pppBlack
+        }
+        
+        locationLabel.do {
+            $0.font = .pppCaption1
+            $0.textColor = .pppGrey6
+        }
+        
+        infoStackView.do {
+            $0.axis = .vertical
+            $0.alignment = .leading
+            $0.spacing = 5
+        }
+    }
+    
+    func setConstraint() {
+        contentView.addSubviews(placeImageView,
+                                infoStackView
+        )
+    }
+    
+    func setLayout() {
+        placeImageView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.width.equalTo(84)
+        }
+        
+        infoStackView.snp.makeConstraints {
+            $0.centerY.equalTo(placeImageView)
+            $0.leading.equalTo(placeImageView.snp.trailing).offset(12)
+        }
+    }
+}
+
+extension SearchTableViewCell {
+    func dataBind(image: UIImage, name: String, location: String) {
+        placeImageView.image = image
+        placeNameLabel.text = name
+        locationLabel.text = location
+    }
+}

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
@@ -12,10 +12,6 @@ import Then
 
 class SearchTableViewCell: UITableViewCell {
     
-    // MARK: - Properties
-    
-    static let identifier = "SearchTableViewCell"
-    
     // MARK: - UI Components
     
     lazy var placeImageView = UIImageView()
@@ -24,7 +20,7 @@ class SearchTableViewCell: UITableViewCell {
     private lazy var infoStackView = UIStackView(arrangedSubviews: [placeNameLabel,
                                                                     locationLabel])
     
-    // MARK: - init
+    // MARK: - Lift Cycles
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -73,8 +69,9 @@ class SearchTableViewCell: UITableViewCell {
     
     func setLayout() {
         placeImageView.snp.makeConstraints {
-            $0.top.leading.equalToSuperview()
+            $0.top.bottom.equalToSuperview().inset(12)
             $0.height.width.equalTo(84)
+            $0.leading.equalToSuperview()
         }
         
         infoStackView.snp.makeConstraints {

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
@@ -74,11 +74,10 @@ final class SearchView: UIView {
             $0.top.equalTo(searchBar.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(28)
             $0.bottom.equalToSuperview()
-            
         }
         
         searchHeaderView.snp.makeConstraints {
-            $0.height.equalTo(28)
+            $0.height.equalTo(46)
         }
     }
 }

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
@@ -11,11 +11,19 @@ import SnapKit
 import Then
 
 final class SearchView: UIView {
+    
+    // MARK: - Properties
+    
+    let placeholder: String = "지역명으로 검색해보세요 ex) 서초구"
+    private lazy var attributedString = NSMutableAttributedString(string: placeholder,
+                                                     attributes: [NSAttributedString.Key.font: UIFont.pppBody4 ,
+                                                                  NSAttributedString.Key.foregroundColor: UIColor.pppGrey5])
         
     // MARK: - UI Components
     
-    lazy var searchTableView = UITableView()
-    private lazy var searchLabel = UILabel()
+    lazy var searchTableView = UITableView(frame: .zero, style: .grouped)
+    lazy var searchBar = UISearchBar()
+    lazy var searchHeaderView = SearchHeaderView()
     
     // MARK: - Life Cycle
     
@@ -37,32 +45,40 @@ final class SearchView: UIView {
         searchTableView.do {
             $0.separatorStyle = .none
             $0.showsVerticalScrollIndicator = false
+            $0.backgroundColor = .white
         }
         
-        searchLabel.do {
-            $0.text = "전체"
-            $0.font = .pppSubHead1
-            $0.textColor = .pppBlack
+        searchBar.do {
+            $0.showsCancelButton = false
+            $0.backgroundImage = UIImage()
+            $0.searchTextField.backgroundColor = .pppGrey2
+            $0.searchTextField.leftView?.tintColor = .pppGrey5
+            $0.searchTextField.attributedPlaceholder = attributedString
         }
     }
     
     private func hierarchy() {
-        self.addSubviews(searchLabel,
-                         searchTableView
+        self.addSubviews(searchTableView,
+                         searchBar
         )
     }
     
     private func layout() {
-        searchLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(30)
-            $0.leading.equalToSuperview().inset(28)
-            $0.height.equalTo(24)
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(40)
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+                
+        searchTableView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(28)
+            $0.bottom.equalToSuperview()
+            
         }
         
-        searchTableView.snp.makeConstraints {
-            $0.top.equalTo(searchLabel.snp.bottom).offset(24)
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalToSuperview()
+        searchHeaderView.snp.makeConstraints {
+            $0.height.equalTo(28)
         }
     }
 }

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
@@ -5,4 +5,44 @@
 //  Created by 류희재 on 2023/07/03.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchView: UIView {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private lazy var searchTableView = UITableView()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        style()
+        hierarchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {
+    
+    }
+    
+    private func hierarchy() {
+
+    }
+    
+    private func layout() {
+
+    }
+}

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
@@ -11,12 +11,11 @@ import SnapKit
 import Then
 
 final class SearchView: UIView {
-    
-    // MARK: - Properties
-    
+        
     // MARK: - UI Components
     
-    private lazy var searchTableView = UITableView()
+    lazy var searchTableView = UITableView()
+    private lazy var searchLabel = UILabel()
     
     // MARK: - Life Cycle
     
@@ -35,14 +34,35 @@ final class SearchView: UIView {
     // MARK: - Custom Method
     
     private func style() {
-    
+        searchTableView.do {
+            $0.separatorStyle = .none
+            $0.showsVerticalScrollIndicator = false
+        }
+        
+        searchLabel.do {
+            $0.text = "전체"
+            $0.font = .pppSubHead1
+            $0.textColor = .pppBlack
+        }
     }
     
     private func hierarchy() {
-
+        self.addSubviews(searchLabel,
+                         searchTableView
+        )
     }
     
     private func layout() {
-
+        searchLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(30)
+            $0.leading.equalToSuperview().inset(28)
+            $0.height.equalTo(24)
+        }
+        
+        searchTableView.snp.makeConstraints {
+            $0.top.equalTo(searchLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview()
+        }
     }
 }

--- a/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
@@ -7,9 +7,86 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 final class SearchViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    private let dummy = SearchListModel.dummy()
+    
+    // MARK: - UI Components
+    
+    private lazy var searchView = SearchView()
+    
+    // MARK: - Life Cycles
+    
     override func viewDidLoad() {
-        self.view.backgroundColor = .blue
+        super.viewDidLoad()
+    
+        target()
+        register()
+        delegate()
+        
+        style()
+        hierarchy()
+        layout()
+    }
+    
+    // MARK: - Custom Method
+
+    private func target() {}
+
+    private func register() {
+        searchView.searchTableView.register(SearchTableViewCell.self,
+                                            forCellReuseIdentifier: SearchTableViewCell.cellIdentifier)
+    }
+
+    private func delegate() {
+        searchView.searchTableView.dataSource = self
+        searchView.searchTableView.delegate = self
+    }
+
+    private func style() {}
+
+    private func hierarchy() {
+        view.addSubviews(searchView)
+    }
+
+    private func layout() {
+        searchView.snp.makeConstraints {
+            $0.leading.trailing.top.bottom.equalToSuperview()
+        }
     }
 }
 
+// MARK: - UITableViewDataSource
+
+extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.contentView.preservesSuperviewLayoutMargins = true
+        cell.contentView.layoutMargins.top = 10 // 셀의 위 간격을 10 포인트로 설정
+        cell.contentView.layoutMargins.bottom = 10 // 셀의 아래 간격을 10 포인트로 설정
+    }
+}
+
+extension SearchViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return dummy.searchList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SearchTableViewCell.cellIdentifier,
+                                                 for: indexPath) as? SearchTableViewCell ?? SearchTableViewCell()
+        cell.selectionStyle = .none
+        cell.dataBind(image: dummy.searchList[indexPath.row].image,
+                      name: dummy.searchList[indexPath.row].name,
+                      location: dummy.searchList[indexPath.row].location)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 108
+    }
+}

--- a/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
@@ -46,6 +46,7 @@ final class SearchViewController: BaseViewController {
     private func delegate() {
         searchView.searchTableView.dataSource = self
         searchView.searchTableView.delegate = self
+        searchView.searchBar.delegate = self
     }
 
     private func style() {}
@@ -63,13 +64,7 @@ final class SearchViewController: BaseViewController {
 
 // MARK: - UITableViewDataSource
 
-extension SearchViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cell.contentView.preservesSuperviewLayoutMargins = true
-        cell.contentView.layoutMargins.top = 10 // 셀의 위 간격을 10 포인트로 설정
-        cell.contentView.layoutMargins.bottom = 10 // 셀의 아래 간격을 10 포인트로 설정
-    }
-}
+extension SearchViewController: UITableViewDelegate {}
 
 extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -89,4 +84,18 @@ extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 108
     }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return searchView.searchHeaderView
+    }
+}
+
+extension SearchViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        print(searchController.searchBar.text!)
+    }
+}
+
+extension SearchViewController: UISearchBarDelegate {
+    
 }

--- a/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Search/ViewController/SearchViewController.swift
@@ -87,7 +87,7 @@ extension SearchViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return searchView.searchHeaderView
-    }
+    }    
 }
 
 extension SearchViewController: UISearchResultsUpdating {


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #25 

### ✅ 작업한 내용
- SearchView UI 구현 완료했습니당

### ❗️PR Point
- 아직 기능 구현은 안해서 `UISearchResultsUpdating` 프로토콜 필수구현 함수는 그냥 비워둔 채로 냅뒀습니다!

### 📸 스크린샷
<img src= "https://github.com/Indipage/PPPiOS/assets/109334968/1bf7c1dc-3e4c-4a41-9bf2-54ec2ce63b38" width="400">

### ✏️ 배운점 & 참고 레퍼런스

1. SearchBar의 이것저것을 변경하는 방법들에 대해서 배웟씁니다!
- [iOS SearchBar 이것저것 건들여보기](https://www.zehye.kr/ios/2021/10/13/iOS_search_bar_custom/)

2. `TableHeaderView`는 높이가 동적으로 할당되기 때문에, `header`를 지정해주고 싶을 때는 `TableHeaderView`보다 Section의 `header`를 지정해주는게 낫다는 걸 배웠습니다..... 딱히 레퍼런스는 없지만 그냥 깨달아씀.... TableHeaderView높이 동적할당 넘 열바듬....
3. cell 간의 간격을 설정해주는 방법을 모르겠어서 이것저것 찾아보고 반영해보려 했지만... 실패했씁니당^^.... 왜 반영이 안되는지 공부해봐야할 것 같습니당
- [UITableViewCell의 간격을 조정하는 방법](https://pooh-footprints.tistory.com/80)

### ✏️ 공부할 것
1. guard let 과 if let의 차이점
2. 옵셔널 바인딩


closed #25 
