### PR TITLE
[Fix]  #80 - HomeView Ticket 여부에 따른 hidden 처리 코드 수정

### DIFF
--- a/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
+++ b/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
@@ -127,7 +127,7 @@ class HomeArticleFooterView: UITableViewHeaderFooterView {
         ticketID = articleData.ticket.id
         ticketURL = articleData.ticket.ticketImageURL
         cardURL = articleData.ticket.cardImageURL
-        ticketReceived = false
+        ticketReceived = articleData.hasReceivedTicket
         
         if !ticketReceived {
             ticketButton.setImage(Image.mockNoTicket, for: .normal)

--- a/PPPCLUB-iOS/Presentation/Home/View/HomeWeeklyView.swift
+++ b/PPPCLUB-iOS/Presentation/Home/View/HomeWeeklyView.swift
@@ -64,7 +64,7 @@ class HomeWeeklyView: UIView {
         ticketCoverImageView.do {
             $0.image = Image.mockArticleCardPacked
             $0.isUserInteractionEnabled = true
-            $0.isHidden = slideCheck
+            $0.isHidden = true
         }
     }
     

--- a/PPPCLUB-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -201,7 +201,13 @@ extension HomeViewController: UICollectionViewDataSource {
 //MARK: - SavedArticleCellDelegate
 
 extension HomeViewController: SavedArticleCellDelegate {
-    
+    func articleDidTap() {
+        let articleViewController = HomeArticleViewController()
+        self.navigationController?.pushViewController(articleViewController, animated: true)
+    }
+}
+
+extension HomeViewController {
     func dataBindArticleCard(articleData: HomeArticleCardResult?) {
         guard let articleData = articleData else { return }
         rootView.homeWeeklyView.cardId = articleData.id
@@ -215,12 +221,7 @@ extension HomeViewController: SavedArticleCellDelegate {
     
     func dataBindArticleSlideCheck(articleData: HomeArticleCheckResult?) {
         guard let hasSlide = articleData?.hasSlide else { return }
-        rootView.homeWeeklyView.slideCheck = hasSlide
-    }
-    
-    func articleDidTap() {
-        let articleViewController = HomeArticleViewController()
-        self.navigationController?.pushViewController(articleViewController, animated: true)
+        rootView.homeWeeklyView.ticketCoverImageView.isHidden = hasSlide
     }
     
     func requestArticleCardAPI() {
@@ -250,3 +251,5 @@ extension HomeViewController: SavedArticleCellDelegate {
         }
     }
 }
+    
+    


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #80 

### ✅ 작업한 내용
- HomeView Ticket 의 slide 여부에 따른 hidden 처리의 코드를 수정하였습니다.

### ❗️PR Point
- 초기값을 isHidden = false 로 설정해놓고 다시 isHidden 을 바꿔준다면 티켓의 이미지가 떴다가 사라지게 됩니다. 하지만 처음부터 isHidden 을 true 로 해준 뒤 Slide 여부에 따라 분기처리 해준다면 더욱 부드러운 뷰가 완성됩니다.

### 📸 스크린샷
### ✏️ 배운점 & 참고 레퍼런스



closed #80 
