### PR TITLE
[Feat] - #83 Search View API 연동

### DIFF
--- a/PPPCLUB-iOS.xcodeproj/project.pbxproj
+++ b/PPPCLUB-iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		0525C73A2A67261E00699B2C /* DetailGetFollowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C7392A67261E00699B2C /* DetailGetFollowModel.swift */; };
 		0525C73C2A67533A00699B2C /* DetailRecommendBookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C73B2A67533A00699B2C /* DetailRecommendBookModel.swift */; };
 		0525C73E2A675DD000699B2C /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C73D2A675DD000699B2C /* Detail.swift */; };
+		0525C7402A6932EA00699B2C /* SearchSpaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C73F2A6932EA00699B2C /* SearchSpaceModel.swift */; };
+		0525C7432A69338700699B2C /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C7422A69338700699B2C /* SearchService.swift */; };
+		0525C7452A69362B00699B2C /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C7442A69362B00699B2C /* SearchAPI.swift */; };
 		0557DDDB2A65F71100650F75 /* DetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDA2A65F71100650F75 /* DetailService.swift */; };
 		0557DDDD2A65F92900650F75 /* DetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDC2A65F92900650F75 /* DetailAPI.swift */; };
 		0557DDDF2A65FD7200650F75 /* DetailSavedBookMarkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDE2A65FD7200650F75 /* DetailSavedBookMarkModel.swift */; };
@@ -148,6 +151,9 @@
 		0525C7392A67261E00699B2C /* DetailGetFollowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGetFollowModel.swift; sourceTree = "<group>"; };
 		0525C73B2A67533A00699B2C /* DetailRecommendBookModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRecommendBookModel.swift; sourceTree = "<group>"; };
 		0525C73D2A675DD000699B2C /* Detail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Detail.swift; sourceTree = "<group>"; };
+		0525C73F2A6932EA00699B2C /* SearchSpaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSpaceModel.swift; sourceTree = "<group>"; };
+		0525C7422A69338700699B2C /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		0525C7442A69362B00699B2C /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
 		0557DDDA2A65F71100650F75 /* DetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailService.swift; sourceTree = "<group>"; };
 		0557DDDC2A65F92900650F75 /* DetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAPI.swift; sourceTree = "<group>"; };
 		0557DDDE2A65FD7200650F75 /* DetailSavedBookMarkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSavedBookMarkModel.swift; sourceTree = "<group>"; };
@@ -291,6 +297,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0525C7412A69337D00699B2C /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				0525C7422A69338700699B2C /* SearchService.swift */,
+				0525C7442A69362B00699B2C /* SearchAPI.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		0557DDD92A65F6FA00650F75 /* Detail */ = {
 			isa = PBXGroup;
 			children = (
@@ -357,6 +372,7 @@
 			isa = PBXGroup;
 			children = (
 				05CD07E12A5EA072003EEE84 /* SearchListModel.swift */,
+				0525C73F2A6932EA00699B2C /* SearchSpaceModel.swift */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -581,6 +597,7 @@
 		D2614A8B2A5290CC00869710 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0525C7412A69337D00699B2C /* Search */,
 				2C1796562A670FB30020B9A5 /* Home */,
 				0557DDD92A65F6FA00650F75 /* Detail */,
 				D2B031B02A631A1800DE8896 /* Ticket */,
@@ -807,8 +824,8 @@
 			isa = PBXGroup;
 			children = (
 				D2B096192A529994007BC756 /* SearchView.swift */,
-				05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */,
 				05CD07E42A5ED7D8003EEE84 /* SearchHeaderView.swift */,
+				05CD07DC2A5E9C37003EEE84 /* SearchTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -978,10 +995,12 @@
 				D22188882A5BF8BA00F097C7 /* CGPoint+.swift in Sources */,
 				05CD07D52A5C9690003EEE84 /* DetailUniqueView.swift in Sources */,
 				D2614A462A52836E00869710 /* AppDelegate.swift in Sources */,
+				0525C7402A6932EA00699B2C /* SearchSpaceModel.swift in Sources */,
 				0525C7382A66EA7900699B2C /* DetailGetSpaceModel.swift in Sources */,
 				2C17965F2A67353C0020B9A5 /* HomeArticleCheckModel.swift in Sources */,
 				D2B096222A5299CC007BC756 /* HomeView.swift in Sources */,
 				2C0C72992A60696100EC2117 /* HomeArticleView.swift in Sources */,
+				0525C7432A69338700699B2C /* SearchService.swift in Sources */,
 				D2B031A62A62B32300DE8896 /* MyUserInfoModel.swift in Sources */,
 				0525C73A2A67261E00699B2C /* DetailGetFollowModel.swift in Sources */,
 				D2B096262A529AC4007BC756 /* PPPTabBarController.swift in Sources */,
@@ -1064,6 +1083,7 @@
 				2C0C72AA2A608BB000EC2117 /* HomeWeeklyView.swift in Sources */,
 				05CD07DD2A5E9C37003EEE84 /* SearchTableViewCell.swift in Sources */,
 				2C0C729D2A60699600EC2117 /* HomeArticleCollectionView.swift in Sources */,
+				0525C7452A69362B00699B2C /* SearchAPI.swift in Sources */,
 				2C1F44112A649B4D006CEF71 /* HomeArticleParsing.swift in Sources */,
 				D2B096162A529963007BC756 /* TicketTicketView.swift in Sources */,
 				D2B031972A61397E00DE8896 /* MySavedArticleTableViewCell.swift in Sources */,

--- a/PPPCLUB-iOS/Data/Search/APIModel/SearchSpaceModel.swift
+++ b/PPPCLUB-iOS/Data/Search/APIModel/SearchSpaceModel.swift
@@ -1,0 +1,24 @@
+//
+//  SearchSpaceModel.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/20.
+//
+
+import UIKit
+
+struct SearchGetSpaceResult: Codable {
+    let data: [SpaceData]
+}
+
+struct SpaceData: Codable {
+    let spaceID: Int
+    let spaceName, address: String
+    let imageURL: String?
+
+    enum CodingKeys: String, CodingKey {
+        case spaceID = "spaceId"
+        case spaceName, address
+        case imageURL = "imageUrl"
+    }
+}

--- a/PPPCLUB-iOS/Global/Constant/URLs.swift
+++ b/PPPCLUB-iOS/Global/Constant/URLs.swift
@@ -19,7 +19,7 @@ public enum URLs{
     //MARK: - Search
     
     static let getSpace = "/space/{spaceId}"
-    static let getSearchSpace = "/space/list?keyword={}"
+    static let getSearchSpace = "/space/list"
     
     //MARK: - Detail
     

--- a/PPPCLUB-iOS/Network/Search/SearchAPI.swift
+++ b/PPPCLUB-iOS/Network/Search/SearchAPI.swift
@@ -1,0 +1,36 @@
+//
+//  SearchAPI.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/20.
+//
+
+import UIKit
+
+import Moya
+
+final class SearchAPI: BaseAPI {
+    static let shared = SearchAPI()
+    private var searchProvider = MoyaProvider<SearchService>(plugins: [MoyaLoggingPlugin()])
+    private override init() {}
+}
+
+extension SearchAPI {
+    public func getSearchSpace(keyword: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        searchProvider.request(.getSearchSpace(keyword: keyword)) { (result) in
+            self.disposeNetwork(result,
+                                dataModel: [SpaceData].self,
+                                completion: completion
+            )
+        }
+    }
+    
+    public func getAllSpace(completion: @escaping (NetworkResult<Any>) -> Void) {
+        searchProvider.request(.getAllSpace) { (result) in
+            self.disposeNetwork(result,
+                                dataModel: [SpaceData].self,
+                                completion: completion
+            )
+        }
+    }
+}

--- a/PPPCLUB-iOS/Network/Search/SearchService.swift
+++ b/PPPCLUB-iOS/Network/Search/SearchService.swift
@@ -1,0 +1,44 @@
+//
+//  SearchService.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/07/20.
+//
+
+import UIKit
+
+import Moya
+
+enum SearchService {
+    case getSearchSpace(keyword: String)
+    case getAllSpace
+}
+
+extension SearchService: BaseTargetType {
+    var path: String {
+        switch self {
+        case .getSearchSpace(_):
+            return URLs.getSearchSpace
+        case .getAllSpace:
+            return URLs.getSearchSpace
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getSearchSpace:
+            return .get
+        case .getAllSpace:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getSearchSpace(let keyword):
+            return .requestParameters(parameters: ["keyword": keyword], encoding: URLEncoding.queryString)
+        case .getAllSpace:
+            return .requestPlain
+        }
+    }
+}

--- a/PPPCLUB-iOS/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Detail/ViewController/DetailViewController.swift
@@ -14,7 +14,7 @@ final class DetailViewController: BaseViewController {
     
     // MARK: - Properties
     
-    private var spaceID = 1
+    var spaceID = 1
     private var isFollowed: Bool = false
     private var hashTagList: [String] = [String]()
     private var recommandBookData: [DetailRecommendBookResult] = [] {

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchTableViewCell.swift
@@ -13,7 +13,7 @@ import Then
 class SearchTableViewCell: UITableViewCell {
     
     // MARK: - UI Components
-    
+    var id = 0
     lazy var placeImageView = UIImageView()
     lazy var placeNameLabel = UILabel()
     lazy var locationLabel = UILabel()
@@ -84,12 +84,6 @@ class SearchTableViewCell: UITableViewCell {
 }
 
 extension SearchTableViewCell {
-    func dataBind(image: UIImage, name: String, location: String) {
-        placeImageView.image = image
-        placeNameLabel.text = name
-        locationLabel.text = location
-    }
-    
     func dataBind2(image: String, name: String, location: String) {
         placeImageView.kfSetImage(url: image)
         placeNameLabel.text = name

--- a/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
+++ b/PPPCLUB-iOS/Presentation/Search/View/SearchView.swift
@@ -24,6 +24,15 @@ final class SearchView: UIView {
     lazy var searchTableView = UITableView(frame: .zero, style: .grouped)
     lazy var searchBar = UISearchBar()
     lazy var searchHeaderView = SearchHeaderView()
+    lazy var noResultImageView = UIImageView()
+    lazy var noSpaceLabel = UILabel()
+    lazy var noRegistedPlaceLabel = UILabel()
+    lazy var checkAddressLabel = UILabel()
+    lazy var noResultLabelStackView = UIStackView(arrangedSubviews: [noSpaceLabel,
+                                                                     noRegistedPlaceLabel,
+                                                                     checkAddressLabel
+                                                                    ]
+    )
     
     // MARK: - Life Cycle
     
@@ -57,11 +66,43 @@ final class SearchView: UIView {
             $0.searchTextField.attributedPlaceholder = attributedString
             $0.showsCancelButton = false
         }
+        
+        noResultImageView.do {
+            $0.image = Image.blankPlace
+            $0.isHidden = true
+        }
+        
+        noSpaceLabel.do {
+            $0.text = "검색된 공간이 없어요"
+            $0.font = .pppBody1
+            $0.textColor = .pppGrey5
+        }
+        
+        noRegistedPlaceLabel.do {
+            $0.text = "- 아직 미등록된 공간일 수 있어요"
+            $0.font = .pppBody5
+            $0.textColor = .pppGrey4
+        }
+        
+        checkAddressLabel.do {
+            $0.text = "- 지역명이 정확한지 확인해보세요"
+            $0.font = .pppBody5
+            $0.textColor = .pppGrey4
+        }
+        
+        noResultLabelStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 7
+            $0.alignment = .center
+            $0.isHidden = true
+        }
     }
     
     private func hierarchy() {
         self.addSubviews(searchTableView,
-                         searchBar
+                         searchBar,
+                         noResultImageView,
+                         noResultLabelStackView
         )
     }
     
@@ -80,6 +121,18 @@ final class SearchView: UIView {
         
         searchHeaderView.snp.makeConstraints {
             $0.height.equalTo(46)
+        }
+        
+        noResultImageView.snp.makeConstraints {
+            $0.height.equalTo(96)
+            $0.width.equalTo(84)
+            $0.center.equalToSuperview()
+        }
+        
+        noResultLabelStackView.snp.makeConstraints {
+            $0.top.equalTo(noResultImageView.snp.bottom).offset(16)
+            $0.centerX.equalTo(noResultImageView)
+            $0.width.equalTo(212)
         }
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #83 

### ✅ 작업한 내용
- 공간검색 API 연동 완료
- 검색 결과 존재하지 않을 시, 분기처리
- DetailView로 화면 전환

### ❗️PR Point
- searchViewController에서 검색 로직 구성할 때 그냥 bool값 몇개 사용해서 짰는데 이거보다 좋은 방법이 있을까요?

### 📸 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-21 at 04 07 01](https://github.com/Indipage/PPPiOS/assets/109334968/7b7091d7-16d4-4145-9739-2c643a0cbd88)

### ✏️ 배운점 & 참고 레퍼런스
1. data 안에 배열이 들어올 때 API 메서드와 Model을 만드는 방법을 헷갈려하는 것 같은데 아마도 서버통신 코드를 제대로 이해하지 못하고 사용했기 때문인 것 같다.. 희재오빠 말로는 Moya가 alamofire를 너무 경량화했기 때문에 alamofire를 잘 모르면 이해하기 어려울 수 있다고 했었는데, 나중에 꼭 서버통신 코드를 하나씩 뜯어보고 그래도 이해가 안되면 alamofire 공부를 해보는 것도 좋을 것 같다


closed #83 
