### PR TITLE
[Fix] #112 아티클 푸터 뷰 오류 수정

### DIFF
--- a/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
+++ b/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
@@ -65,7 +65,7 @@ class HomeArticleFooterView: UITableViewHeaderFooterView {
         }
         
         ticketSubLabel.do {
-            $0.text = "이번 주 아티클은 잘 읽으셨나요?\nPPPclub에서 드리는 티켓을 가지고\n문학살롱 초고에 방문하여 인증받아보세요!"
+            $0.text = ""
             $0.font = .systemFont(ofSize: 15)
             $0.textColor = .pppBlack
             $0.setLineSpacing(spacing: 10)
@@ -112,8 +112,6 @@ class HomeArticleFooterView: UITableViewHeaderFooterView {
             $0.height.equalTo(383)
             $0.bottom.equalToSuperview().inset(91)
         }
-        
-        
     }
     
     //MARK: - Action Method
@@ -136,6 +134,11 @@ class HomeArticleFooterView: UITableViewHeaderFooterView {
             ticketButton.kfSetButtonImage(url: ticketURL, state: .normal)
             ticketButton.isEnabled = false
         }
+    }
+    
+    func dataBindTicketCheck2(articleData: HomeDetailArticleResult?) {
+        guard let articleData = articleData else { return }
+        ticketSubLabel.text = "이번 주 아티클은 잘 읽으셨나요?\nPPPclub에서 드리는 티켓을 가지고\n\(articleData.spaceName)에 방문하여 인증받아보세요!"
     }
 }
 

--- a/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
+++ b/PPPCLUB-iOS/Presentation/Home/HomeHeaderFooterView/HomeArticleFooterView.swift
@@ -131,7 +131,7 @@ class HomeArticleFooterView: UITableViewHeaderFooterView {
             ticketButton.setImage(Image.mockNoTicket, for: .normal)
         }
         else {
-            ticketButton.kfSetButtonImage(url: ticketURL, state: .normal)
+            ticketButton.kfSetButtonImage(url: ticketURL, state: .disabled)
             ticketButton.isEnabled = false
         }
     }

--- a/PPPCLUB-iOS/Presentation/Home/ViewController/HomeArticleViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Home/ViewController/HomeArticleViewController.swift
@@ -184,6 +184,7 @@ extension HomeArticleViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: HomeArticleFooterView.cellIdentifier) as? HomeArticleFooterView else { return UIView()}
         footer.dataBindTicketCheck(articleData: ticketCheckData)
+        footer.dataBindTicketCheck2(articleData: homeDetailArticleData)
         return footer
     }
     


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #112 

### ✅ 작업한 내용
- 아티클 페이지 에서 티켓 흐릿하게 보이는 에러
- 아티클 페이지 푸터 뷰에 서점 이름 서버 연결

### ❗️PR Point
- 버튼을  isEnabled = false 하였을 때 버튼의 이미지가 블러처리 되는 오류를 수정하였습니다. 블러처리 되는 이유는 User 에게 isEnabled 가 false 처리 되었다는 것을 알리기 위하여 자동으로 설정되는 것이므로 아래 코드 처럼 '.normal' 를 '.disabled' 로 수정하여 오류를 해결하였습니둥 ~!

```swift
if !ticketReceived {
            ticketButton.setImage(Image.mockNoTicket, for: .normal)
}
else {
            ticketButton.kfSetButtonImage(url: ticketURL, state: .disabled)
            ticketButton.isEnabled = false
}
```

### 📸 스크린샷

![Simulator Screenshot - iPhone 14 - 2023-08-25 at 00 20 49](https://github.com/Indipage/PPPiOS/assets/103318297/15717714-33d0-4f02-aeda-f2fe4d0a1977)

### ✏️ 배운점 & 참고 레퍼런스

1. 아래처럼 한 함수 안에 dataBind 를 여러 개 쓴 코드가 처음이다. 두근거린다.

```swift
func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
        guard let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: HomeArticleFooterView.cellIdentifier) as? HomeArticleFooterView else { return UIView()}
        footer.dataBindTicketCheck(articleData: ticketCheckData)
        footer.dataBindTicketCheck2(articleData: homeDetailArticleData)
        return footer
    }
```


closed #112 
