### PR TITLE
[Feat] #126 자동로그인 구현

### DIFF
--- a/PPPCLUB-iOS.xcodeproj/project.pbxproj
+++ b/PPPCLUB-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0525C7402A6932EA00699B2C /* SearchSpaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C73F2A6932EA00699B2C /* SearchSpaceModel.swift */; };
 		0525C7432A69338700699B2C /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C7422A69338700699B2C /* SearchService.swift */; };
 		0525C7452A69362B00699B2C /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0525C7442A69362B00699B2C /* SearchAPI.swift */; };
+		0545C6D02AD3CE75007C60F3 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0545C6CF2AD3CE75007C60F3 /* TokenManager.swift */; };
 		0557DDDB2A65F71100650F75 /* DetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDA2A65F71100650F75 /* DetailService.swift */; };
 		0557DDDD2A65F92900650F75 /* DetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDC2A65F92900650F75 /* DetailAPI.swift */; };
 		0557DDDF2A65FD7200650F75 /* DetailSavedBookMarkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0557DDDE2A65FD7200650F75 /* DetailSavedBookMarkModel.swift */; };
@@ -179,6 +180,7 @@
 		0525C73F2A6932EA00699B2C /* SearchSpaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSpaceModel.swift; sourceTree = "<group>"; };
 		0525C7422A69338700699B2C /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		0525C7442A69362B00699B2C /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
+		0545C6CF2AD3CE75007C60F3 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		0557DDDA2A65F71100650F75 /* DetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailService.swift; sourceTree = "<group>"; };
 		0557DDDC2A65F92900650F75 /* DetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAPI.swift; sourceTree = "<group>"; };
 		0557DDDE2A65FD7200650F75 /* DetailSavedBookMarkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSavedBookMarkModel.swift; sourceTree = "<group>"; };
@@ -692,6 +694,7 @@
 				D2614A952A52917B00869710 /* NetworkResult.swift */,
 				D2614A972A52918A00869710 /* BaseTargetType.swift */,
 				D2614A992A52919A00869710 /* BaseAPI.swift */,
+				0545C6CF2AD3CE75007C60F3 /* TokenManager.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1273,6 +1276,7 @@
 				2CC8E6352A68353B00C117D7 /* HomeBookmarkCheckModel.swift in Sources */,
 				D265940C2A5C88A80089E56A /* TicketCollectionViewCell.swift in Sources */,
 				055E51C32A6329F5001BD991 /* UIImage+.swift in Sources */,
+				0545C6D02AD3CE75007C60F3 /* TokenManager.swift in Sources */,
 				D2614A642A528C6400869710 /* UIViewController+.swift in Sources */,
 				058326892A5C00C7004A295F /* DetailTagCollectionViewCell.swift in Sources */,
 				D2E8C3DF2A5F3934002004A5 /* TicketFailureViewController.swift in Sources */,

--- a/PPPCLUB-iOS/Network/Foundation/APIConstants.swift
+++ b/PPPCLUB-iOS/Network/Foundation/APIConstants.swift
@@ -16,6 +16,7 @@ struct APIConstants{
     static let auth = "Authorization"
     static let refresh = "RefreshToken"
     static let fcm = "FcmToken"
+    static let accessToken = TokenManager.shared.getToken()
     
 }
 
@@ -27,7 +28,7 @@ extension APIConstants{
     
     static var hasTokenHeader: Dictionary<String,String> {
         [contentType: applicationJSON,
-               auth : ""]
+               auth : "\(accessToken)"]
     }
 }
 

--- a/PPPCLUB-iOS/Network/Foundation/TokenManager.swift
+++ b/PPPCLUB-iOS/Network/Foundation/TokenManager.swift
@@ -1,0 +1,38 @@
+//
+//  TokenManager.swift
+//  PPPCLUB-iOS
+//
+//  Created by 박윤빈 on 2023/10/09.
+//
+
+import UIKit
+
+class TokenManager {
+    
+    static let shared = TokenManager()
+    let defaults = UserDefaults.standard
+    
+    func isTokenExist() -> Bool {
+        let token = defaults.string(forKey: "accessToken")
+        if token != nil {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func saveToken(token: String) {
+        defaults.set(token, forKey: "accessToken")
+    }
+    
+    func getToken() -> String {
+        return defaults.string(forKey: "accessToken") ?? ""
+    }
+    
+    // MARK: - 로그아웃, 탈퇴 및 로그인 테스트시 사용
+    
+    func removeToken() {
+        defaults.removeObject(forKey: "accessToken")
+    }
+    
+}

--- a/PPPCLUB-iOS/Presentation/Onboarding/ViewController/OnboardingAgreementViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Onboarding/ViewController/OnboardingAgreementViewController.swift
@@ -166,6 +166,7 @@ extension OnboardingAgreementViewController {
     func requestAppleLoginAPI() {
         OnboardingAPI.shared.postLogin(accessToken: accesstoken, platform: Platform.apple) { result in
             guard let result = self.validateResult(result) as? OnboardingLoginResult else { return }
+            TokenManager.shared.saveToken(token: result.accessToken)
             let PPPTabBarC = PPPTabBarController()
             self.navigationController?.pushViewController(PPPTabBarC, animated: true)
         }

--- a/PPPCLUB-iOS/Presentation/Onboarding/ViewController/OnboardingLoginViewController.swift
+++ b/PPPCLUB-iOS/Presentation/Onboarding/ViewController/OnboardingLoginViewController.swift
@@ -27,6 +27,7 @@ final class OnboardingLoginViewController : UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        checkToken()
         target()
     }
     
@@ -34,6 +35,13 @@ final class OnboardingLoginViewController : UIViewController {
     
     private func target() {
         rootView.appleLoginButton.addTarget(self, action: #selector(appleLoginButtonDidTap), for: .touchUpInside)
+    }
+    
+    private func checkToken() {
+        if TokenManager.shared.isTokenExist() {
+            let PPPTabBar = PPPTabBarController()
+            self.navigationController?.pushViewController(PPPTabBar, animated: true)
+        }
     }
     
     //MARK: - Action Method


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #126 

### ✅ 작업한 내용
- UserDefaults 이용해서 토큰 로컬디비에 저장하고, 확인하여 자동으로 로그인 되도록 구현 완료했습니다.
- Network -> Foundation ->`TokenManager` 파일 만들어서, 사용할 함수 구현해두고, 해당 파일에서 함수 불러와 사용할 수 있도록 구현했습니다.
- 이후 로그아웃이나 탈퇴 만들 때 사용하라고 로컬디비에서 토큰 지우는 함수도 같이 만들어 두었습니다

### ❗️PR Point
- 음 UserDefaults 코드가 여기저기 분산되어 있는게 싫어서 UserDefaults 자체가 싱글톤으로 돌아가는데도 불구하고 또 제가 따로 싱글톤 패턴으로 구현해줬는데요,, 좋은 방법인지 잘 모르겠습니다. 파일 저렇게 따로 만들 바에 그냥 코드 분산시켜놓는게 나을까요..? 아니면 저거 말고 더 좋은 방법이 있을까요..? 의견주시면 감사감사링
- 만약에 한번 자동로그인이 된 이후에도 처음부터 다시 테스트 해보고 싶다면, `TokenManger.shared.removeToken()` 을 로그인 뷰의 viewDidLoad에서 한번 작성하고 빌드하신 후, 코드 지우고 다시 빌드해서 테스트해주시면 됩니다

### 📸 스크린샷
![Simulator Screen Recording - iPhone 14 - 2023-10-09 at 15 37 17](https://github.com/Indipage/PPPiOS/assets/109334968/07276de2-7671-4969-a3be-5a8158efb91a)


### ✏️ 배운점 & 참고 레퍼런스
맨날 Realm만 쓰다가 처음 UserDefaults를 써보는데, 생각보다 사용법이 간단하더라구요 공부했던 링크 첨부하겠읍니다
- https://velog.io/@nnnyeong/iOS-UserDefaults-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0

- https://velog.io/@gnwjd309/iOS-UserDefaults

closed #126 
